### PR TITLE
fix: add TTL to redis error logs

### DIFF
--- a/src/Elmah.AspNetCore.StackExchange.Redis/RedisErrorLog.cs
+++ b/src/Elmah.AspNetCore.StackExchange.Redis/RedisErrorLog.cs
@@ -67,7 +67,7 @@ public class RedisErrorLog : ErrorLog
 
         return this.ReadErrorFromRedis(value);
     }
-    
+
     public override async Task<int> GetErrorsAsync(ErrorLogFilterCollection errorLogFilters, int errorIndex, int pageSize, ICollection<ErrorLogEntry> entries, CancellationToken cancellationToken)
     {
         int count = 0;
@@ -112,7 +112,7 @@ public class RedisErrorLog : ErrorLog
             // append key so we can easily rehydrate
             RedisValue errorXml = $"{error.Id:N}{ErrorXml.EncodeString(error)}";
             RedisKey key = this.GetErrorKey(error.Id);
-            await db.StringSetAsync(key, errorXml);
+            await db.StringSetAsync(key, errorXml, expiry: _options.ErrorLogTtl);
 
             var len = await db.ListLeftPushAsync(_listKey, key.ToString());
             if (len > _options.MaximumSize)

--- a/src/Elmah.AspNetCore.StackExchange.Redis/RedisErrorLogOptions.cs
+++ b/src/Elmah.AspNetCore.StackExchange.Redis/RedisErrorLogOptions.cs
@@ -23,6 +23,11 @@ public class RedisErrorLogOptions
     public int MaximumSize { get; set; } = 200;
 
     /// <summary>
+    /// Gets or sets the time to live for the error record. This sets the expiration on the redis key.
+    /// </summary>
+    public TimeSpan ErrorLogTtl { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>
     /// Gets or sets a Redis connection to be used when accessing the redis server.
     /// </summary>
     public Func<Task<IConnectionMultiplexer>>? ConnectionMultiplexerFactory { get; set; }


### PR DESCRIPTION
Set TTL for Redis logs with default of 24h

fixes #110 