### PR TITLE
Max errors change

### DIFF
--- a/src/Elmah.AspNetCore.Common/Configuration/ElmahOptions.cs
+++ b/src/Elmah.AspNetCore.Common/Configuration/ElmahOptions.cs
@@ -70,5 +70,11 @@ public class ElmahOptions
     /// </summary>
     public bool LogSqlQueryParameters { get; set; } = true;
 
+
+    /// <summary>
+    ///     Gets or sets a value the maximum errors to show in the user interface's errors list (Default is 100)
+    /// </summary>
+    public int MaxUiErrors { get; set; } = 100;
+
     public virtual Task Error(HttpContext context, Error error) => OnError(context, error);
 }

--- a/src/Elmah.AspNetCore/Configuration/EndpointRouteBuilderExtensions.cs
+++ b/src/Elmah.AspNetCore/Configuration/EndpointRouteBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Elmah.AspNetCore.Handlers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Elmah.AspNetCore;
 
@@ -13,8 +14,10 @@ public static class EndpointRouteBuilderExtensions
 
     public static IEndpointConventionBuilder MapElmah(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string prefix)
     {
-        var options = endpoints.ServiceProvider.GetRequiredService<ElmahEnvironment>();
-        options.Path = prefix;
+        var elmahEnvironment = endpoints.ServiceProvider.GetRequiredService<ElmahEnvironment>();
+        var elmahOptions = endpoints.ServiceProvider.GetRequiredService<IOptions<ElmahOptions>>().Value;
+        elmahEnvironment.Path = prefix;
+        elmahEnvironment.MaxUiErrors = elmahOptions.MaxUiErrors;
 
 #if NET7_0_OR_GREATER
         var group = endpoints.MapGroup(prefix);

--- a/src/Elmah.AspNetCore/ElmahEnvironment.cs
+++ b/src/Elmah.AspNetCore/ElmahEnvironment.cs
@@ -5,4 +5,5 @@ namespace Elmah.AspNetCore;
 internal sealed class ElmahEnvironment
 {
     public PathString Path { get; set; }
+    public int MaxUiErrors { get; set; }
 }

--- a/src/Elmah.AspNetCore/Handlers/ErrorApiHandler.cs
+++ b/src/Elmah.AspNetCore/Handlers/ErrorApiHandler.cs
@@ -142,6 +142,7 @@ internal static partial class Endpoints
 
     private static async Task<(int, List<ErrorLogEntryWrapper>)> GetNewErrorsAsync(ErrorLog errorLog, Guid errorGuid, ErrorLogFilterCollection errorFilters, CancellationToken cancellationToken)
     {
+        const int pageSize = 10;
         int page = 0;
         var buffer = new List<ErrorLogEntry>(10);
         var returnList = new List<ErrorLogEntryWrapper>();
@@ -149,8 +150,8 @@ internal static partial class Endpoints
         do
         {
             buffer.Clear();
-            int count = await errorLog.GetErrorsAsync(errorFilters, page, 10, buffer, cancellationToken);
-            
+            int count = await errorLog.GetErrorsAsync(errorFilters, page * pageSize, pageSize, buffer, cancellationToken);
+
             foreach (var el in buffer)
             {
                 if (el.Id == errorGuid)

--- a/src/Elmah.AspNetCore/Handlers/ErrorResourceHandler.cs
+++ b/src/Elmah.AspNetCore/Handlers/ErrorResourceHandler.cs
@@ -33,7 +33,8 @@ internal static partial class Endpoints
 
         var elmahRoot = context.GetElmahRelativeRoot();
         var html = await reader.ReadToEndAsync();
-        html = html.Replace("ELMAH_ROOT", elmahRoot);
+        html = html.Replace("ELMAH_ROOT", elmahRoot).Replace("ELMAH_CONFIG", "{maxErrors:100}");
+
         return Results.Content(html, MediaTypeNames.Text.Html);
     }
 

--- a/src/Elmah.AspNetCore/Handlers/ErrorResourceHandler.cs
+++ b/src/Elmah.AspNetCore/Handlers/ErrorResourceHandler.cs
@@ -32,8 +32,9 @@ internal static partial class Endpoints
         using var reader = new StreamReader(stream);
 
         var elmahRoot = context.GetElmahRelativeRoot();
+        var maxErrors = context.GetElmahMaxUiErrors();
         var html = await reader.ReadToEndAsync();
-        html = html.Replace("ELMAH_ROOT", elmahRoot).Replace("ELMAH_CONFIG", "{maxErrors:100}");
+        html = html.Replace("ELMAH_ROOT", elmahRoot).Replace("ELMAH_CONFIG", $"{{maxErrors:{maxErrors}}}");
 
         return Results.Content(html, MediaTypeNames.Text.Html);
     }

--- a/src/Elmah.AspNetCore/HttpContextExtensions.cs
+++ b/src/Elmah.AspNetCore/HttpContextExtensions.cs
@@ -16,6 +16,11 @@ internal static class HttpContextExtensions
         var options = context.RequestServices.GetRequiredService<ElmahEnvironment>();
         return context.Request.PathBase.Add(options.Path);
     }
+    public static int GetElmahMaxUiErrors(this HttpContext context)
+    {
+        var options = context.RequestServices.GetRequiredService<ElmahEnvironment>();
+        return options.MaxUiErrors;
+    }
 
     public static string GetElmahAbsoluteRoot(this HttpContext context)
     {

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -11,7 +11,7 @@
     <noscript>
       <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
-    <script type="text/javascript">window.$elmah_root = "ELMAH_ROOT";</script>
+    <script type="text/javascript">window.$elmah_root = "ELMAH_ROOT";window.$elmah_config = ELMAH_CONFIG;</script>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -54,6 +54,7 @@
 <script>
 import ErrorListFilter from "@/components/ErrorListFilter";
 import store from "./store";
+import config from "./config";
 
 export default {
   name: "App",
@@ -71,7 +72,7 @@ export default {
   },
   computed: {
     elmah_root: function () {
-      return window.$elmah_root;
+      return config.getPath();
     },
   },
 };

--- a/ui/src/components/ErrorDetail.vue
+++ b/ui/src/components/ErrorDetail.vue
@@ -662,6 +662,7 @@
 
 <script>
 import axios from "axios";
+import config from "../config";
 
 export default {
   name: "ErrorDetail",
@@ -685,7 +686,7 @@ export default {
       return document.getElementById("items-container");
     },
     elmah_root: function () {
-      return window.$elmah_root;
+      return config.getPath();
     },
     body: function () {
       try {

--- a/ui/src/components/ErrorListFilter.vue
+++ b/ui/src/components/ErrorListFilter.vue
@@ -102,6 +102,7 @@
 
 <script>
 import store from "./../store";
+import config from "./../config";
 import dateFormat from "dateformat";
 
 export default {
@@ -237,7 +238,7 @@ export default {
   },
   computed: {
     elmah_root: function () {
-      return window.$elmah_root;
+      return config.getPath();
     },
     isErrorsPage() {
       return this.$route.name === "Errors";

--- a/ui/src/components/ErrorsList.vue
+++ b/ui/src/components/ErrorsList.vue
@@ -181,7 +181,10 @@ export default {
             id +
             "&q=" +
             encodeURIComponent(searchText),
-          filterTags
+          filterTags,
+          {
+            timeout: 1234
+          }
         )
         .then((response) => {
           if (
@@ -189,7 +192,8 @@ export default {
             response.data.errors &&
             response.data.errors.length
           ) {
-            var size = Math.min(100, response.data.totalCount);
+            var maxErrors = window.$elmah_config && window.$elmah_config.maxErrors ? window.$elmah_config.maxErrors : 100;
+            var size = Math.min(maxErrors, response.data.totalCount);
             ctx.items = response.data.errors.concat(ctx.items).slice(0, size);
             this.totalCount = response.data.totalCount;
             this.errorIndex += response.data.errors.length;

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,0 +1,11 @@
+const config = {
+  getPath: () => {
+    return window.$elmah_root || "/elmah";
+  },
+  getMaxErrors: () => {
+    return window.$elmah_config && window.$elmah_config.maxErrors
+      ? window.$elmah_config.maxErrors
+      : 100;
+  },
+};
+export default config;

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
+import config from "../config";
 import About from "@/views/About.vue";
 import Detail from "@/views/Detail";
 import List from "@/views/List";
@@ -41,7 +42,7 @@ const routes = [
 
 const router = new VueRouter({
   mode: "history",
-  base: window.$elmah_root || "/elmah",
+  base: config.getPath(),
   routes,
   linkExactActiveClass: "exact-active",
   linkActiveClass: "active",

--- a/ui/src/views/Detail.vue
+++ b/ui/src/views/Detail.vue
@@ -6,6 +6,7 @@
 
 <script>
 import axios from "axios";
+import config from "../config";
 import ErrorDetail from "@/components/ErrorDetail";
 export default {
   name: "Detail",
@@ -18,7 +19,7 @@ export default {
   components: { ErrorDetail },
   mounted() {
     axios
-      .get((window.$elmah_root || "/elmah") + "/api/error?id=" + this.id)
+      .get(config.getPath() + "/api/error?id=" + this.id)
       .then((response) => {
         this.item = response.data.error;
       })


### PR DESCRIPTION
I found an issue that when you scroll down it will load more errors (50 at a time) but the hard coded max errors in the Vue file means that if a new error comes in it will truncate where you were up to if you are past 100 errors, so this PR changes that by tracking the max errors based upon if you scroll down it will add 50 to the allowed max errors. 

Additionally i added the max errors function into the server side component of new-error as there was no point to supply 200 errors only for the UI to ignore half of it.

In this PR i also tried to come up with a hopefully acceptable way to supply the UI with some server supplied configuration which could be expanded upon, that bit is open to some ideas and discussion but I think I've done it along a similar lines to the root url component.